### PR TITLE
ci: migrate LizardByte/setup-python-action

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: LizardByte/setup-python-action@master
+      uses: LizardByte/actions/actions/setup_python@master
       with:
         python-version: ${{ matrix.python-version }}
     - name: Build package


### PR DESCRIPTION
LizardByte/setup-python-action is deprecated and has moved to LizardByte/actions.